### PR TITLE
add in jenkins-war in test scope to allow mvn hpi:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,14 @@
             <artifactId>workflow-job</artifactId>
             <version>1.11</version>
         </dependency>
-
+        <!-- add dependency to enable local testing of the plugin-->
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <type>war</type>
+            <version>1.645</version>
+            <scope>test</scope>
+        </dependency>
         <!-- mockito for mocking in tests -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/jenkins/plugins/hygieia/utils/CodeQualityMetricsConverter.java
+++ b/src/main/java/jenkins/plugins/hygieia/utils/CodeQualityMetricsConverter.java
@@ -64,7 +64,7 @@ public class CodeQualityMetricsConverter implements QualityVisitor<CodeQuality> 
 
     @Override
     public void visit(FindBugsXmlReport findBugReport) {
-        Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = createEmptyVioldationsMap();
+        Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = createEmptyViolationsMap();
 
         // loop over all the stuff in the report and accumulate violations.
         if (null != findBugReport.getFiles()) {
@@ -214,7 +214,7 @@ public class CodeQualityMetricsConverter implements QualityVisitor<CodeQuality> 
 
     @Override
     public void visit(PmdReport pmdReport) {
-        Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = createEmptyVioldationsMap();
+        Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = createEmptyViolationsMap();
 
         // loop over all the stuff in the report and accumulate violations.
         if (null != pmdReport.getFiles()) {
@@ -257,7 +257,7 @@ public class CodeQualityMetricsConverter implements QualityVisitor<CodeQuality> 
 
     @Override
     public void visit(CheckstyleReport checkstyleReport) {
-        Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = createEmptyVioldationsMap();
+        Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = createEmptyViolationsMap();
 
         // loop over all the stuff in the report and accumulate violations.
         if (null != checkstyleReport.getFiles()) {
@@ -303,7 +303,7 @@ public class CodeQualityMetricsConverter implements QualityVisitor<CodeQuality> 
         return quality;
     }
 
-    private Map<String, Pair<Integer, CodeQualityMetricStatus>> createEmptyVioldationsMap() {
+    private Map<String, Pair<Integer, CodeQualityMetricStatus>> createEmptyViolationsMap() {
         Map<String, Pair<Integer, CodeQualityMetricStatus>> metricsMap = new HashMap<>();
         metricsMap.put(BLOCKER_VIOLATIONS, Pair.of(0, CodeQualityMetricStatus.Ok));
         metricsMap.put(CRITICAL_VIOLATIONS, Pair.of(0, CodeQualityMetricStatus.Ok));


### PR DESCRIPTION
This dependency allows a local jenkins server to be spun up by using the command `mvn hpi:run` as per the documentation here: https://www.jenkins.io/doc/developer/tutorial/run/

This allows for easy local sanity testing of the plugin so you can debug any issues

It is test scope, so it'll not be included in the build of the plugin itself.

Also correct a typo.