### PR TITLE
Added the clientReference from BuildCreateResponse to be propagated t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jenkins-test-harness.version>2.34</jenkins-test-harness.version>
+        <com.capitalone.dashboard.core.version>3.14.17</com.capitalone.dashboard.core.version>
     </properties>
 
     <licenses>
@@ -97,7 +98,7 @@
         <dependency>
             <groupId>com.capitalone.dashboard</groupId>
             <artifactId>core</artifactId>
-            <version>3.14.14</version>
+            <version>${com.capitalone.dashboard.core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <artifactId>hygieia-publisher</artifactId>
     <packaging>hpi</packaging>
-    <version>2.2.5-SNAPSHOT</version>
+    <version>2.2.6-SNAPSHOT</version>
     <name>Hygieia Publisher Plugin</name>
     <description>A Build status publisher that notifies Hygieia</description>
     <url>https://github.com/Hygieia/hygieia-publisher-jenkins-plugin</url>

--- a/src/main/java/jenkins/plugins/hygieia/DefaultHygieiaService.java
+++ b/src/main/java/jenkins/plugins/hygieia/DefaultHygieiaService.java
@@ -80,7 +80,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v3/build", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v3/build", jsonString, request.getClientReference());
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {
@@ -144,7 +144,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v2/quality/static-analysis", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v2/quality/static-analysis", jsonString, request.getClientReference());
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {
@@ -184,7 +184,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/generic-item", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/generic-item", jsonString, request.getClientReference());
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {
@@ -227,7 +227,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/metadata/create", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/metadata/create", jsonString, request.getClientReference());
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {

--- a/src/main/java/jenkins/plugins/hygieia/HygieiaGlobalListener.java
+++ b/src/main/java/jenkins/plugins/hygieia/HygieiaGlobalListener.java
@@ -144,15 +144,17 @@ public class HygieiaGlobalListener extends RunListener<Run<?, ?>> {
             String hygieiaAppUrl = (CollectionUtils.size(appUrls) > index) ? appUrls.get(index) : null;
             String convertedBuildResponseString = null;
             String dashboardLink = null;
+            BuildDataCreateResponse buildDataCreateResponse = null;
 
             Triple<String, String, BuildDataCreateResponse> buildResponseTriple = publishBuildData(run, listener, hygieiaGlobalListenerDescriptor, hygieiaService, hygieiaAppUrl);
 
             if (buildResponseTriple != null) {
                 convertedBuildResponseString = buildResponseTriple.getLeft();
                 dashboardLink = buildResponseTriple.getMiddle();
+                buildDataCreateResponse = buildResponseTriple.getRight();
             }
-            publishSonarData(run, listener, hygieiaGlobalListenerDescriptor, hygieiaService, StringUtils.trimToNull(convertedBuildResponseString));
-            publishGenericCollectorItemsOnEnd(run, listener, hygieiaGlobalListenerDescriptor, hygieiaService, StringUtils.trimToNull(convertedBuildResponseString));
+            publishSonarData(run, listener, hygieiaGlobalListenerDescriptor, hygieiaService, StringUtils.trimToNull(convertedBuildResponseString), buildDataCreateResponse);
+            publishGenericCollectorItemsOnEnd(run, listener, hygieiaGlobalListenerDescriptor, hygieiaService, StringUtils.trimToNull(convertedBuildResponseString), buildDataCreateResponse);
 
             // publish the dashboard link
             if (showConsoleOutput && StringUtils.isNotEmpty(dashboardLink)) {
@@ -283,7 +285,8 @@ public class HygieiaGlobalListener extends RunListener<Run<?, ?>> {
        return url;
     }
 
-    private void publishSonarData(Run run, TaskListener listener, HygieiaPublisher.DescriptorImpl hygieiaGlobalListenerDescriptor, HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString) {
+    private void publishSonarData(Run run, TaskListener listener, HygieiaPublisher.DescriptorImpl hygieiaGlobalListenerDescriptor,
+                                  HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString, BuildDataCreateResponse buildDataCreateResponse) {
         if (!hygieiaGlobalListenerDescriptor.isHygieiaPublishSonarDataGlobal()) { return; }
         boolean showConsoleOutput = hygieiaGlobalListenerDescriptor.isShowConsoleOutput();
         try {
@@ -291,6 +294,9 @@ public class HygieiaGlobalListener extends RunListener<Run<?, ?>> {
             CodeQualityCreateRequest request = buildCodeQualityCreateRequest(run, listener, hygieiaGlobalListenerDescriptor.getHygieiaJenkinsName(),
                     convertedBuildResponseString, hygieiaGlobalListenerDescriptor.isUseProxy());
             if (request != null) {
+                if(buildDataCreateResponse != null && StringUtils.isNotEmpty(buildDataCreateResponse.getClientReference())){
+                    request.setClientReference(buildDataCreateResponse.getClientReference());
+                }
                 HygieiaResponse sonarResponse = hygieiaService.publishSonarResults(request);
                 if (sonarResponse.getResponseCode() == HttpStatus.SC_CREATED) {
                     if (showConsoleOutput) { listener.getLogger().println("Hygieia: Auto Published Sonar Data. " + sonarResponse.toString()); }
@@ -305,27 +311,30 @@ public class HygieiaGlobalListener extends RunListener<Run<?, ?>> {
         }
     }
 
-    private void publishGenericCollectorItemsOnEnd(Run run, TaskListener listener, HygieiaPublisher.DescriptorImpl hygieiaGlobalListenerDescriptor, HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString) {
+    private void publishGenericCollectorItemsOnEnd(Run run, TaskListener listener, HygieiaPublisher.DescriptorImpl hygieiaGlobalListenerDescriptor,
+                                                   HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString, BuildDataCreateResponse buildDataCreateResponse) {
         if (CollectionUtils.isEmpty(hygieiaGlobalListenerDescriptor.getHygieiaPublishGenericCollectorItems())) { return; }
         boolean showConsoleOutput = hygieiaGlobalListenerDescriptor.isShowConsoleOutput();
         List<HygieiaPublisher.GenericCollectorItem> publishItems = hygieiaGlobalListenerDescriptor.getHygieiaPublishGenericCollectorItems().stream().filter(p -> !p.isPublishOnStart()).collect(Collectors.toList());
-        publishItems(run, listener, publishItems, showConsoleOutput, hygieiaService, convertedBuildResponseString);
+        String clientReference = (Objects.isNull(buildDataCreateResponse)) ? null : buildDataCreateResponse.getClientReference();
+        publishItems(run, listener, publishItems, showConsoleOutput, hygieiaService, convertedBuildResponseString, clientReference);
     }
 
     private void publishGenericCollectorItemsOnStart(Run run, TaskListener listener, HygieiaPublisher.DescriptorImpl hygieiaGlobalListenerDescriptor, HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString) {
         if (CollectionUtils.isEmpty(hygieiaGlobalListenerDescriptor.getHygieiaPublishGenericCollectorItems())) { return; }
         boolean showConsoleOutput = hygieiaGlobalListenerDescriptor.isShowConsoleOutput();
         List<HygieiaPublisher.GenericCollectorItem> publishItems = hygieiaGlobalListenerDescriptor.getHygieiaPublishGenericCollectorItems().stream().filter(p -> p.isPublishOnStart()).collect(Collectors.toList());
-        publishItems(run, listener, publishItems, showConsoleOutput, hygieiaService, convertedBuildResponseString);
+        publishItems(run, listener, publishItems, showConsoleOutput, hygieiaService, convertedBuildResponseString, null);
     }
 
-    private void publishItems(Run run, TaskListener listener, List<HygieiaPublisher.GenericCollectorItem> items,boolean showConsoleOutput, HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString) {
+    private void publishItems(Run run, TaskListener listener, List<HygieiaPublisher.GenericCollectorItem> items,boolean showConsoleOutput, HygieiaService hygieiaService, @Nonnull String convertedBuildResponseString, String clientReference) {
         if (CollectionUtils.isEmpty(items)) { return; }
         for (HygieiaPublisher.GenericCollectorItem item : items) {
             try {
                 List<GenericCollectorItemCreateRequest> genericCollectorItemCreateRequests = GenericCollectorItemBuilder.getInstance().getRequests(run, item.toolName, item.pattern, convertedBuildResponseString);
                 if (CollectionUtils.isEmpty(genericCollectorItemCreateRequests)) continue;
                 for (GenericCollectorItemCreateRequest gcir : genericCollectorItemCreateRequests) {
+                    gcir.setClientReference(clientReference);
                     HygieiaResponse genericItemResponse = hygieiaService.publishGenericCollectorItemData(gcir);
                     if (showConsoleOutput) { listener.getLogger().println("Hygieia: Auto Published " + gcir.getToolName() + " Data. " + genericItemResponse.toString()); }
                 }

--- a/src/main/java/jenkins/plugins/hygieia/HygieiaGlobalListener.java
+++ b/src/main/java/jenkins/plugins/hygieia/HygieiaGlobalListener.java
@@ -188,8 +188,9 @@ public class HygieiaGlobalListener extends RunListener<Run<?, ?>> {
 
         String startedBy = HygieiaUtils.getUserID(run, listener);
         if(showConsoleOutput) { listener.getLogger().println("Hygieia: This build was initiated by " + startedBy); }
-        HygieiaResponse buildResponse = hygieiaService.publishBuildDataV3(new BuildBuilder().createBuildRequestFromRun(run, hygieiaGlobalListenerDescriptor.getHygieiaJenkinsName(),
-                listener, buildStatus, true, buildStages, startedBy));
+        BuildDataCreateRequest buildDataCreateRequest = new BuildBuilder().createBuildRequestFromRun(run, hygieiaGlobalListenerDescriptor.getHygieiaJenkinsName(),
+                listener, buildStatus, true, buildStages, startedBy);
+        HygieiaResponse buildResponse = hygieiaService.publishBuildDataV3(buildDataCreateRequest);
         if (buildResponse.getResponseCode() == HttpStatus.SC_CREATED) {
             try {
                 buildDataResponse = HygieiaUtils.convertJsonToObject(buildResponse.getResponseValue(), BuildDataCreateResponse.class);

--- a/src/main/java/jenkins/plugins/hygieia/RestCall.java
+++ b/src/main/java/jenkins/plugins/hygieia/RestCall.java
@@ -101,7 +101,7 @@ public class RestCall {
                     "application/json",
                     "UTF-8");
             post.setRequestEntity(requestEntity);
-            post.addRequestHeader(CommonConstants.HEADER_API_USER,API_USER);
+            post.addRequestHeader(CommonConstants.HEADER_API_USER, API_USER);
             int responseCode = client.executeMethod(post);
             String responseString = getResponseString(post.getResponseBodyAsStream());
             response = new RestCallResponse(responseCode, responseString);
@@ -124,7 +124,7 @@ public class RestCall {
                     "application/json",
                     "UTF-8");
             post.setRequestEntity(requestEntity);
-            post.addRequestHeader(CommonConstants.HEADER_API_USER,API_USER);
+            post.addRequestHeader(CommonConstants.HEADER_API_USER, API_USER);
             post.addRequestHeader(CommonConstants.HEADER_CLIENT_CORRELATION_ID, clientReference);
             int responseCode = client.executeMethod(post);
             String responseString = getResponseString(post.getResponseBodyAsStream());
@@ -144,7 +144,7 @@ public class RestCall {
         GetMethod get = new GetMethod(url);
         try {
             get.getParams().setContentCharset("UTF-8");
-            get.addRequestHeader(CommonConstants.HEADER_API_USER,API_USER);
+            get.addRequestHeader(CommonConstants.HEADER_API_USER, API_USER);
             int responseCode = client.executeMethod(get);
             String responseString = getResponseString(get.getResponseBodyAsStream());
             response = new RestCallResponse(responseCode, responseString);


### PR DESCRIPTION
- `clientReference` associated to build is propagated to other calls to api
- Added default `apiUser`  (`hygieia_publisher_plugin`) to rest calls made to hygieia-api
- Added `clientReference` as a header to rest calls made to hygieia-api
- added buildUrl to publish methods